### PR TITLE
Potential fix for code scanning alert no. 48: Uncontrolled data used in path expression

### DIFF
--- a/src/main/java/org/owasp/webgoat/webwolf/FileServer.java
+++ b/src/main/java/org/owasp/webgoat/webwolf/FileServer.java
@@ -71,8 +71,12 @@ public class FileServer {
     destinationDir.mkdirs();
     // DO NOT use multipartFile.transferTo(), see
     // https://stackoverflow.com/questions/60336929/java-nio-file-nosuchfileexception-when-file-transferto-is-called
+    String originalFilename = multipartFile.getOriginalFilename();
+    if (originalFilename.contains("..") || originalFilename.contains("/") || originalFilename.contains("\\")) {
+      throw new IllegalArgumentException("Invalid filename");
+    }
     try (InputStream is = multipartFile.getInputStream()) {
-      var destinationFile = destinationDir.toPath().resolve(multipartFile.getOriginalFilename());
+      var destinationFile = destinationDir.toPath().resolve(originalFilename);
       Files.deleteIfExists(destinationFile);
       Files.copy(is, destinationFile);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/A-Gordon/WebGoat/security/code-scanning/48](https://github.com/A-Gordon/WebGoat/security/code-scanning/48)

To fix the problem, we need to validate the filename obtained from `multipartFile.getOriginalFilename()` to ensure it does not contain any path traversal characters or separators. This can be done by checking for the presence of "..", "/", or "\\" in the filename and rejecting the upload if any are found.

The best way to fix the problem without changing existing functionality is to add a validation step before constructing the `destinationFile` path. If the filename is invalid, we should throw an `IllegalArgumentException`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
