### PR TITLE
Potential fix for code scanning alert no. 54: Incomplete string escaping or encoding

### DIFF
--- a/src/main/resources/webgoat/static/js/libs/jquery-ui-1.10.4.js
+++ b/src/main/resources/webgoat/static/js/libs/jquery-ui-1.10.4.js
@@ -7224,7 +7224,7 @@ var lastActive, startXPos, startYPos, clickDragged,
 			form = radio.form,
 			radios = $( [] );
 		if ( name ) {
-			name = name.replace( /'/g, "\\'" );
+			name = name.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
 			if ( form ) {
 				radios = $( form ).find( "[name='" + name + "']" );
 			} else {


### PR DESCRIPTION
Potential fix for [https://github.com/A-Gordon/WebGoat/security/code-scanning/54](https://github.com/A-Gordon/WebGoat/security/code-scanning/54)

To fix the problem, we need to ensure that backslashes are also escaped in the `name` variable. This can be done by using a regular expression with the `g` flag to replace all occurrences of both single quotes and backslashes. The best way to fix this without changing existing functionality is to update the `name.replace` line to handle both characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
